### PR TITLE
Enable SSL certificate verification by default

### DIFF
--- a/bin/nzrealme
+++ b/bin/nzrealme
@@ -31,6 +31,7 @@ if(!GetOptions(\%opt,
     'type|t=s',
     'allow_create|allow-create',
     'resolve_flt|resolve-flt',
+    'disable_ssl_verify|disable-ssl-verify',
     'env=s',
     'org=s',
     'org_unit|org-unit=s',
@@ -208,6 +209,11 @@ Optional additional details to go on the end of the certificate subject field.
 The CN will be calculated for you based on --domain.  The O and OU will be
 added based on --org and --org-unit.  Prefix each fieldname with a forward
 slash (e.g.: --subject /L=Wellington/ST=Wellington/C=NZ).
+
+=item B<< --disable-ssl-verify >>
+
+When using the C<resolve> command, this option will cause the service provider
+to disable the SSL certificate checks that would take place otherwise.
 
 =item B<< --to-file <filename> >>
 

--- a/lib/Authen/NZRealMe.pm
+++ b/lib/Authen/NZRealMe.pm
@@ -83,10 +83,12 @@ sub _sp_from_opt {
     my $opt        = shift;
 
     my $service_type = $opt->{type} || "login";
-    return $class->service_provider(
+    my %sp_options = (
         conf_dir  => _conf_dir($opt),
         type      => $service_type,
     );
+    $sp_options{disable_ssl_verify} = $opt->{disable_ssl_verify} if $opt->{disable_ssl_verify};
+    return $class->service_provider(%sp_options);
 }
 
 

--- a/lib/Authen/NZRealMe/ServiceProvider.pm
+++ b/lib/Authen/NZRealMe/ServiceProvider.pm
@@ -24,6 +24,7 @@ use WWW::Curl::Easy qw(
     CURLOPT_SSL_VERIFYPEER
     CURLOPT_WRITEDATA
     CURLOPT_WRITEHEADER
+    CURLOPT_CAPATH
 );
 
 use constant DATETIME_BEFORE => -1;
@@ -37,6 +38,7 @@ my $signing_key_filename  = 'sp-sign-key.pem';
 my $ssl_cert_filename     = 'sp-ssl-crt.pem';
 my $ssl_key_filename      = 'sp-ssl-key.pem';
 my $icms_wsdl_filename    = 'metadata-icms.wsdl';
+my $ca_cert_directory     = 'ca-certs';
 
 
 my $ns_md       = [ md    => 'urn:oasis:names:tc:SAML:2.0:metadata' ];
@@ -128,6 +130,7 @@ sub signing_cert_pathname  { shift->{conf_dir} . '/' . $signing_cert_filename; }
 sub signing_key_pathname   { shift->{conf_dir} . '/' . $signing_key_filename;  }
 sub ssl_cert_pathname      { shift->{conf_dir} . '/' . $ssl_cert_filename;     }
 sub ssl_key_pathname       { shift->{conf_dir} . '/' . $ssl_key_filename;      }
+sub ca_cert_pathname       { shift->{conf_dir} . '/' . $ca_cert_directory;      }
 
 sub idp {
     my $self = shift;
@@ -537,7 +540,12 @@ sub _https_post {
     $curl->setopt(CURLOPT_POSTFIELDS, $body);
     $curl->setopt(CURLOPT_SSLCERT,    $self->ssl_cert_pathname);
     $curl->setopt(CURLOPT_SSLKEY,     $self->ssl_key_pathname);
-    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 1);
+    $curl->setopt(CURLOPT_CAPATH,     $self->ca_cert_pathname);
+
+    if ($self->{disable_ssl_verify}){
+      $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+    }
 
     my($resp_body, $resp_head);
     open (my $body_fh, ">", \$resp_body);


### PR DESCRIPTION
This will require you to store a copy of the relevant chain
of certificates in a subdirectory of the config dir named
'ca-certs'.

With an OpenSSL derived version of libcurl, you will need
to run the openssl tool 'c_rehash' on 'ca-certs' before
your certificates will validate successfully.

Lastly, and not recommended, this feature may be disabled
by adding '--disable-ssl-verify' to the command.
