### PR TITLE
Add fix for back channel connections via HTTPS proxy

### DIFF
--- a/lib/Authen/NZRealMe/ServiceProvider.pm
+++ b/lib/Authen/NZRealMe/ServiceProvider.pm
@@ -697,6 +697,7 @@ sub _https_post {
     my $resp;
     my $retcode = $curl->perform;
     if($retcode == 0) {
+        $resp_head =~ s/\A(?:HTTP\/1\.1\s+200\s+Connection\s+established).*?\r?\n\r?\n//is; # Remove any '200' response from a proxy
         $resp_head =~ s/\A(?:HTTP\/1\.1 100 Continue)?[\r\n]*//; # Remove any '100' responses and/or leading newlines
         my($status, @head_lines) = split(/\r?\n/, $resp_head);
         my($protocol, $code, $message) = split /\s+/, $status, 3;


### PR DESCRIPTION
- The curl library will use a proxy if the HTTPS_PROXY environment
  variable is set - this is standard, pre-existing behaviour.

- However the code would fail to handle the response received over the
  proxied connection due to the presence of an additional status line and
  header section.

- This change simply discards the "200 Connection established" status line
  and headers resulting from the proxy "CONNECT" command, in exactly the
  same way that the existing code was discarding the "100 Continue"
  response send by the SOAP server before the actual SOAP response.